### PR TITLE
Remove ring.recurse.com from ring

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -1,13 +1,5 @@
 [
   {
-    "website_id": 0,
-    "website_uuid": "0cccc0a0-fa92-4c1a-8da2-b22817103c36",
-    "recurse_id": 0,
-    "website_name": "Other Recurse Webring",
-    "is_anonymous": false,
-    "url": "https://ring.recurse.com"
-  },
-  {
     "website_id": 1,
     "website_uuid": "b101da00-3999-4c31-84b8-491093f49a79",
     "recurse_id": 5993,

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,19 +119,15 @@ async fn get_named_sites(
     let mut sites_with_names = Vec::new();
 
     for site in unnamed_sites {
-        let user_name = match site.recurse_id {
-            0 => "Not A Real Recurser".to_string(),
-            _ => {
-                let response = Client::new()
-                    .get(format!("{}profiles/{}", RECURSE_BASE_URL, site.recurse_id))
-                    .bearer_auth(bearer_token)
-                    .send().await?;
-                let res = response.text().await?;
-                let name = serde_json::from_str::<User>(res.as_str())
-                    .map(|user| user.name);
-                name.unwrap_or("Not A Real Recurser".to_string())
-            }
-        };
+        let response = Client::new()
+            .get(format!("{}profiles/{}", RECURSE_BASE_URL, site.recurse_id))
+            .bearer_auth(bearer_token)
+            .send().await?;
+        let res = response.text().await?;
+    
+        let user_name = serde_json::from_str::<User>(res.as_str())
+            .map(|user| user.name)
+            .unwrap_or("Not A Real Recurser".to_string());
         
         sites_with_names.push(SiteData {
             website_id: site.website_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ const _RECURSE_TOKEN_URL: &str = "https://www.recurse.com/oauth/token";
 
 #[derive(Deserialize)]
 struct ClientTokens {
-    recurse_client_id: String,
+    _recurse_client_id: String,
     recurse_secret: String,
     github_secret: String,
 }

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
@@ -13,8 +13,8 @@
   </head>
   <body>
   <a id="rc-ring-home" data-rc-uuid="0cccc0a0-fa92-4c1a-8da2-b22817103c36"
-  aria-label="An ASCII art Recurse Center Logo with ASCII art text that reads 'Recurse Center'"
-  title="An ASCII art Recurse Center Logo with ASCII art text that reads 'Recurse Center'">
+  aria-label="An ASCII art Recurse Center Logo with ASCII art text that reads 'Recurse Webring'"
+  title="An ASCII art Recurse Center Logo with ASCII art text that reads 'Recurse Webring'">
 <pre><code>███████████████████████████████████████████████████████       
 ███████████████████████████████████████████████████████
 ███████████████████████████████████████████████████████
@@ -83,7 +83,7 @@
     <h3>Why use a webring?</h3>
     Search engines algorithms have always been opaque, but <a href="https://downloads.webis.de/publications/papers/bevendorff_2024a.pdf">it's becoming harder</a> to discover relevant websites using search engines.<br>
     The web is one of the most important inventions in our lives, but commercial entities are not aligned with making it worthwhile to us.<br>
-    Webrings represent a fun, soothing way to share and find meaningful websites that will never be subject to <a href="https://en.wikipedia.org/wiki/Enshittification">enshittification<a>. 
+    Webrings represent a fun, soothing way to share and find meaningful websites that will never be subject to <a href="https://en.wikipedia.org/wiki/Enshittification">enshittification</a>. 
 
     <h3>How do I use this webring?</h3>
     This webring is for alumni of the <a href="https://www.recurse.com/">Recurse Center</a>, which hosts retreats for kind and curious programmers.<br>

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -64,15 +64,16 @@
 ╚███╔███╔╝███████╗██████╔╝██║  ██║██║██║ ╚████║╚██████╔╝ 
  ╚══╝╚══╝ ╚══════╝╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝ ╚═════╝</code></pre></a>
     <hr align="left" width="400">
-    <table width="400" border="0">
+    <!--<table width="400" border="0">
       <tr>
         <td><a id="rc-ring-prev" href="https://ring.recurse.com/prev?id=0">Previous Site</a></td>
         <td><a id="rc-ring-rand" href="https://ring.recurse.com/rand">Random Recurser</a></td>
         <td><a id="rc-ring-next" href="https://ring.recurse.com/next?id=0">Next Site</a></td>
       </tr>
-    </table>
-
-    <h2>A webring for the <a href="https://recurse.com">Recurse Center</a> community</h3>
+    </table> -->
+    <h3><a id="rc-ring-rand" href="https://ring.recurse.com/rand">Click here to start exploring a random Recurser site!</a></h3>
+    <br>
+    <h2>About the <a href="https://recurse.com">Recurse Center</a> Web Ring</h2>
 
     <h3>What is a webring?</h3>
     A webring is a collection of websites linked together in a circular structure, usually focused around a specific topic or community.<br> 


### PR DESCRIPTION
Removes the redundant linking to ring.recurse.com by removing it from the ring itself, and also fixing some minor formatting issues that existed in the ring code. Resolves #1, in PR until I have my AWS keys on-hand.